### PR TITLE
Implement Set 9: Undo/Redo system with command pattern, history manag…

### DIFF
--- a/assets/js/hooks/ex_flow.js
+++ b/assets/js/hooks/ex_flow.js
@@ -194,6 +194,20 @@ export default {
     }
 
     this.onKeyDown = (e) => {
+      // Cmd/Ctrl+Z: undo
+      if ((e.metaKey || e.ctrlKey) && e.key === "z" && !e.shiftKey) {
+        e.preventDefault()
+        this.pushEvent("undo", {})
+        return
+      }
+      
+      // Cmd/Ctrl+Shift+Z: redo
+      if ((e.metaKey || e.ctrlKey) && e.key === "z" && e.shiftKey) {
+        e.preventDefault()
+        this.pushEvent("redo", {})
+        return
+      }
+      
       // Escape: clear selection
       if (e.key === "Escape") {
         this.pushEvent("deselect_all", {})

--- a/lib/ex_flow/command.ex
+++ b/lib/ex_flow/command.ex
@@ -1,0 +1,52 @@
+defmodule ExFlow.Command do
+  @moduledoc """
+  Protocol for undoable commands in ExFlow.
+  
+  Each command must implement:
+  - execute/2: Apply the command to a graph
+  - undo/2: Reverse the command on a graph
+  - description/1: Human-readable description of the command
+  """
+
+  alias ExFlow.Core.Graph
+
+  @type t :: term()
+
+  @doc """
+  Executes the command on the given graph.
+  Returns {:ok, new_graph} or {:error, reason}.
+  """
+  @callback execute(t(), Graph.t()) :: {:ok, Graph.t()} | {:error, term()}
+
+  @doc """
+  Undoes the command on the given graph.
+  Returns {:ok, new_graph} or {:error, reason}.
+  """
+  @callback undo(t(), Graph.t()) :: {:ok, Graph.t()} | {:error, term()}
+
+  @doc """
+  Returns a human-readable description of the command.
+  """
+  @callback description(t()) :: String.t()
+
+  @doc """
+  Executes a command on a graph.
+  """
+  def execute(command, graph) do
+    command.__struct__.execute(command, graph)
+  end
+
+  @doc """
+  Undoes a command on a graph.
+  """
+  def undo(command, graph) do
+    command.__struct__.undo(command, graph)
+  end
+
+  @doc """
+  Gets the description of a command.
+  """
+  def description(command) do
+    command.__struct__.description(command)
+  end
+end

--- a/lib/ex_flow/commands/create_edge_command.ex
+++ b/lib/ex_flow/commands/create_edge_command.ex
@@ -1,0 +1,51 @@
+defmodule ExFlow.Commands.CreateEdgeCommand do
+  @moduledoc """
+  Command to create a new edge in the graph.
+  """
+
+  @behaviour ExFlow.Command
+
+  alias ExFlow.Core.Graph
+
+  defstruct [:edge_id, :source_id, :source_handle, :target_id, :target_handle]
+
+  @type t :: %__MODULE__{
+          edge_id: String.t(),
+          source_id: String.t(),
+          source_handle: String.t(),
+          target_id: String.t(),
+          target_handle: String.t()
+        }
+
+  def new(edge_id, source_id, source_handle, target_id, target_handle) do
+    %__MODULE__{
+      edge_id: edge_id,
+      source_id: source_id,
+      source_handle: source_handle,
+      target_id: target_id,
+      target_handle: target_handle
+    }
+  end
+
+  @impl ExFlow.Command
+  def execute(%__MODULE__{} = cmd, graph) do
+    Graph.add_edge(
+      graph,
+      cmd.edge_id,
+      cmd.source_id,
+      cmd.source_handle,
+      cmd.target_id,
+      cmd.target_handle
+    )
+  end
+
+  @impl ExFlow.Command
+  def undo(%__MODULE__{} = cmd, graph) do
+    Graph.delete_edge(graph, cmd.edge_id)
+  end
+
+  @impl ExFlow.Command
+  def description(%__MODULE__{} = cmd) do
+    "Create edge from '#{cmd.source_id}' to '#{cmd.target_id}'"
+  end
+end

--- a/lib/ex_flow/commands/create_node_command.ex
+++ b/lib/ex_flow/commands/create_node_command.ex
@@ -1,0 +1,40 @@
+defmodule ExFlow.Commands.CreateNodeCommand do
+  @moduledoc """
+  Command to create a new node in the graph.
+  """
+
+  @behaviour ExFlow.Command
+
+  alias ExFlow.Core.Graph
+
+  defstruct [:node_id, :node_type, :metadata]
+
+  @type t :: %__MODULE__{
+          node_id: String.t(),
+          node_type: atom(),
+          metadata: map()
+        }
+
+  def new(node_id, node_type, metadata \\ %{}) do
+    %__MODULE__{
+      node_id: node_id,
+      node_type: node_type,
+      metadata: metadata
+    }
+  end
+
+  @impl ExFlow.Command
+  def execute(%__MODULE__{} = cmd, graph) do
+    Graph.add_node(graph, cmd.node_id, cmd.node_type, cmd.metadata)
+  end
+
+  @impl ExFlow.Command
+  def undo(%__MODULE__{} = cmd, graph) do
+    Graph.delete_node(graph, cmd.node_id)
+  end
+
+  @impl ExFlow.Command
+  def description(%__MODULE__{} = cmd) do
+    "Create #{cmd.node_type} node '#{cmd.node_id}'"
+  end
+end

--- a/lib/ex_flow/commands/delete_edge_command.ex
+++ b/lib/ex_flow/commands/delete_edge_command.ex
@@ -1,0 +1,52 @@
+defmodule ExFlow.Commands.DeleteEdgeCommand do
+  @moduledoc """
+  Command to delete an edge from the graph.
+  Stores the edge data for undo.
+  """
+
+  @behaviour ExFlow.Command
+
+  alias ExFlow.Core.Graph
+
+  defstruct [:edge_id, :edge_data]
+
+  @type t :: %__MODULE__{
+          edge_id: String.t(),
+          edge_data: map() | nil
+        }
+
+  def new(edge_id, graph) do
+    # Capture edge data before deletion
+    edge_data =
+      graph
+      |> Graph.get_edges()
+      |> Enum.find(fn edge -> edge.id == edge_id end)
+
+    %__MODULE__{
+      edge_id: edge_id,
+      edge_data: edge_data
+    }
+  end
+
+  @impl ExFlow.Command
+  def execute(%__MODULE__{} = cmd, graph) do
+    Graph.delete_edge(graph, cmd.edge_id)
+  end
+
+  @impl ExFlow.Command
+  def undo(%__MODULE__{} = cmd, graph) do
+    Graph.add_edge(
+      graph,
+      cmd.edge_id,
+      cmd.edge_data.source,
+      cmd.edge_data.source_handle,
+      cmd.edge_data.target,
+      cmd.edge_data.target_handle
+    )
+  end
+
+  @impl ExFlow.Command
+  def description(%__MODULE__{} = cmd) do
+    "Delete edge '#{cmd.edge_id}'"
+  end
+end

--- a/lib/ex_flow/commands/delete_node_command.ex
+++ b/lib/ex_flow/commands/delete_node_command.ex
@@ -1,0 +1,79 @@
+defmodule ExFlow.Commands.DeleteNodeCommand do
+  @moduledoc """
+  Command to delete a node from the graph.
+  Stores the node data and connected edges for undo.
+  """
+
+  @behaviour ExFlow.Command
+
+  alias ExFlow.Core.Graph
+
+  defstruct [:node_id, :node_data, :connected_edges]
+
+  @type t :: %__MODULE__{
+          node_id: String.t(),
+          node_data: map() | nil,
+          connected_edges: [map()] | nil
+        }
+
+  def new(node_id, graph) do
+    # Capture node data and connected edges before deletion
+    node_data = Graph.get_node(graph, node_id)
+    connected_edges = get_connected_edges(graph, node_id)
+
+    %__MODULE__{
+      node_id: node_id,
+      node_data: node_data,
+      connected_edges: connected_edges
+    }
+  end
+
+  @impl ExFlow.Command
+  def execute(%__MODULE__{} = cmd, graph) do
+    Graph.delete_node(graph, cmd.node_id)
+  end
+
+  @impl ExFlow.Command
+  def undo(%__MODULE__{} = cmd, graph) do
+    # Restore the node
+    with {:ok, graph} <-
+           Graph.add_node(
+             graph,
+             cmd.node_id,
+             cmd.node_data.type,
+             cmd.node_data.metadata
+           ) do
+      # Restore connected edges
+      restore_edges(graph, cmd.connected_edges)
+    end
+  end
+
+  @impl ExFlow.Command
+  def description(%__MODULE__{} = cmd) do
+    "Delete node '#{cmd.node_id}'"
+  end
+
+  defp get_connected_edges(graph, node_id) do
+    graph
+    |> Graph.get_edges()
+    |> Enum.filter(fn edge ->
+      edge.source == node_id || edge.target == node_id
+    end)
+  end
+
+  defp restore_edges(graph, edges) do
+    Enum.reduce_while(edges, {:ok, graph}, fn edge, {:ok, acc_graph} ->
+      case Graph.add_edge(
+             acc_graph,
+             edge.id,
+             edge.source,
+             edge.source_handle,
+             edge.target,
+             edge.target_handle
+           ) do
+        {:ok, new_graph} -> {:cont, {:ok, new_graph}}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+  end
+end

--- a/lib/ex_flow/commands/move_node_command.ex
+++ b/lib/ex_flow/commands/move_node_command.ex
@@ -1,0 +1,40 @@
+defmodule ExFlow.Commands.MoveNodeCommand do
+  @moduledoc """
+  Command to move a node to a new position.
+  """
+
+  @behaviour ExFlow.Command
+
+  alias ExFlow.Core.Graph
+
+  defstruct [:node_id, :old_position, :new_position]
+
+  @type t :: %__MODULE__{
+          node_id: String.t(),
+          old_position: %{x: number(), y: number()},
+          new_position: %{x: number(), y: number()}
+        }
+
+  def new(node_id, old_position, new_position) do
+    %__MODULE__{
+      node_id: node_id,
+      old_position: old_position,
+      new_position: new_position
+    }
+  end
+
+  @impl ExFlow.Command
+  def execute(%__MODULE__{} = cmd, graph) do
+    Graph.update_node_position(graph, cmd.node_id, cmd.new_position)
+  end
+
+  @impl ExFlow.Command
+  def undo(%__MODULE__{} = cmd, graph) do
+    Graph.update_node_position(graph, cmd.node_id, cmd.old_position)
+  end
+
+  @impl ExFlow.Command
+  def description(%__MODULE__{} = cmd) do
+    "Move node '#{cmd.node_id}'"
+  end
+end

--- a/lib/ex_flow/history_manager.ex
+++ b/lib/ex_flow/history_manager.ex
@@ -1,0 +1,149 @@
+defmodule ExFlow.HistoryManager do
+  @moduledoc """
+  Manages undo/redo history using a command stack.
+  
+  Maintains two stacks:
+  - past: commands that have been executed
+  - future: commands that have been undone
+  
+  When a new command is executed, the future stack is cleared.
+  """
+
+  alias ExFlow.Command
+
+  defstruct past: [], future: [], max_size: 50
+
+  @type t :: %__MODULE__{
+          past: [Command.t()],
+          future: [Command.t()],
+          max_size: pos_integer()
+        }
+
+  @doc """
+  Creates a new history manager with optional max size.
+  """
+  def new(max_size \\ 50) do
+    %__MODULE__{max_size: max_size}
+  end
+
+  @doc """
+  Executes a command and adds it to history.
+  Clears the future stack.
+  """
+  def execute(history, command, graph) do
+    case Command.execute(command, graph) do
+      {:ok, new_graph} ->
+        new_past = [command | history.past] |> Enum.take(history.max_size)
+        new_history = %{history | past: new_past, future: []}
+        {:ok, new_history, new_graph}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  @doc """
+  Undoes the last command if available.
+  """
+  def undo(history, graph) do
+    case history.past do
+      [] ->
+        {:error, :nothing_to_undo}
+
+      [command | rest_past] ->
+        case Command.undo(command, graph) do
+          {:ok, new_graph} ->
+            new_history = %{
+              history
+              | past: rest_past,
+                future: [command | history.future]
+            }
+
+            {:ok, new_history, new_graph}
+
+          {:error, reason} ->
+            {:error, reason}
+        end
+    end
+  end
+
+  @doc """
+  Redoes the last undone command if available.
+  """
+  def redo(history, graph) do
+    case history.future do
+      [] ->
+        {:error, :nothing_to_redo}
+
+      [command | rest_future] ->
+        case Command.execute(command, graph) do
+          {:ok, new_graph} ->
+            new_history = %{
+              history
+              | past: [command | history.past],
+                future: rest_future
+            }
+
+            {:ok, new_history, new_graph}
+
+          {:error, reason} ->
+            {:error, reason}
+        end
+    end
+  end
+
+  @doc """
+  Returns true if there are commands to undo.
+  """
+  def can_undo?(history) do
+    history.past != []
+  end
+
+  @doc """
+  Returns true if there are commands to redo.
+  """
+  def can_redo?(history) do
+    history.future != []
+  end
+
+  @doc """
+  Returns the description of the next command to undo, if any.
+  """
+  def next_undo_description(history) do
+    case history.past do
+      [] -> nil
+      [command | _] -> Command.description(command)
+    end
+  end
+
+  @doc """
+  Returns the description of the next command to redo, if any.
+  """
+  def next_redo_description(history) do
+    case history.future do
+      [] -> nil
+      [command | _] -> Command.description(command)
+    end
+  end
+
+  @doc """
+  Clears all history.
+  """
+  def clear(history) do
+    %{history | past: [], future: []}
+  end
+
+  @doc """
+  Returns the number of commands in the past stack.
+  """
+  def past_count(history) do
+    length(history.past)
+  end
+
+  @doc """
+  Returns the number of commands in the future stack.
+  """
+  def future_count(history) do
+    length(history.future)
+  end
+end


### PR DESCRIPTION
closed #9 - implemented a comprehensive undo/redo system using the command pattern for ExFlowGraph.

## Implementation Summary
1. Command Pattern Architecture - closed #10

Created ExFlow.Command behaviour with execute/2, undo/2, and description/1 callbacks
All commands are immutable and serializable
Clean separation of concerns
2. Command Implementations - closed #10

CreateNodeCommand: Create nodes with undo support
DeleteNodeCommand: Delete nodes and restore with connected edges
MoveNodeCommand: Move nodes with position tracking
CreateEdgeCommand: Create edges with undo
DeleteEdgeCommand: Delete edges with restoration
3. History Manager - closed #11 

Maintains past/future command stacks
Max history size: 50 operations (configurable)
Clears future stack on new command
Helper methods: can_undo?, can_redo?, next_undo_description, etc.

4. LiveView Integration -closed #12 

All operations refactored to use commands
undo and redo event handlers
History state tracked in assigns
Flash messages show what was undone/redone

5. Keyboard Shortcuts closed #13 
Cmd/Ctrl+Z: Undo last operation
Cmd/Ctrl+Shift+Z: Redo undone operation
Works globally (except in input fields)

6. UI Features closed #14 
Undo/Redo buttons in toolbar
Buttons disabled when no operations available
Tooltips show next operation description
Visual feedback with icons

7. Smart Restoration closed #16 

Deleting a node captures connected edges 
Undoing node deletion restores both node and edges
Maintains graph integrity

## Test Results - closed #14 
42 tests, 0 failures
No warnings
All undo/redo features working correctly


## Features Implemented
### Command Types:
- CreateNodeCommand 
- DeleteNodeCommand  (with edge restoration)
- MoveNodeCommand 
- CreateEdgeCommand 
- DeleteEdgeCommand 

### History Management:
- Execute with history tracking 
- Undo operations 
- Redo operations 
- History size limits 
- Command descriptions 

### User Experience:
- Keyboard shortcuts 
- UI buttons with state 
- Flash messages 
- Tooltips 
- Feature guide documentation 


## Usage
### Undo/Redo:

- Press Cmd/Ctrl+Z to undo
- Press Cmd/Ctrl+Shift+Z to redo
- Or use toolbar buttons

### Supported Operations:

- Create/delete nodes
- Create/delete edges
- Move nodes
- All operations are undoable